### PR TITLE
Add envelope intro overlay

### DIFF
--- a/Alondra_Website/src/App.jsx
+++ b/Alondra_Website/src/App.jsx
@@ -1,9 +1,14 @@
+import { useState } from 'react';
 import './App.css';
+import Envelope from './Envelope.jsx';
 
 function App() {
+    const [opened, setOpened] = useState(false);
     return (
+        <>
+            {!opened && <Envelope onOpen={() => setOpened(true)} />}
 
-        <div className="min-h-screen bg-gradient-to-br from-pink-200 to-purple-300 flex flex-col items-center justify-center text-center p-6">
+            <div className="min-h-screen bg-gradient-to-br from-pink-200 to-purple-300 flex flex-col items-center justify-center text-center p-6">
             <h1 className="text-5xl font-bold mb-4">🎉 You're Invited! 🎉</h1>
             <h1 className="text-5xl text-red-600 font-bold">Tailwind is working!</h1>
 
@@ -25,6 +30,7 @@ function App() {
                 </form>
             </div>
         </div>
+        </>
     );
 }
 

--- a/Alondra_Website/src/Envelope.css
+++ b/Alondra_Website/src/Envelope.css
@@ -1,0 +1,30 @@
+.envelope-overlay {
+  @apply fixed inset-0 z-50 flex items-center justify-center bg-white;
+  transition: opacity 0.7s ease-in-out;
+}
+
+.envelope-overlay.fade-out {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.envelope-top {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  transform-origin: bottom center;
+  transition: transform 0.7s ease-in-out;
+}
+
+.envelope-top.open {
+  transform: translateY(-100%);
+}
+
+.envelope-stamp {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 4rem;
+  cursor: pointer;
+}

--- a/Alondra_Website/src/Envelope.jsx
+++ b/Alondra_Website/src/Envelope.jsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import stampImg from './assets/Alondra_stamp.png';
+import bottomImg from './assets/alondra_sobre3.png';
+import topImg from './assets/alondra_sobre4.png';
+import './Envelope.css';
+
+export default function Envelope({ onOpen }) {
+  const [opened, setOpened] = useState(false);
+
+  const handleClick = () => {
+    if (opened) return;
+    setOpened(true);
+    setTimeout(() => {
+      if (onOpen) onOpen();
+    }, 700);
+  };
+
+  return (
+    <div className={`envelope-overlay ${opened ? 'fade-out' : ''}`}>
+      <div className="relative">
+        <img src={bottomImg} alt="Envelope bottom" className="block" />
+        <img
+          src={topImg}
+          alt="Envelope top"
+          className={`envelope-top ${opened ? 'open' : ''}`}
+        />
+        <img
+          src={stampImg}
+          alt="Stamp"
+          className="envelope-stamp"
+          onClick={handleClick}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Envelope overlay component and styles
- show envelope on first load and open when stamp clicked

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b31c29a748333aca70d40632e9216