### PR TITLE
Implement full-screen envelope overlay

### DIFF
--- a/Alondra_Website/src/App.css
+++ b/Alondra_Website/src/App.css
@@ -2,3 +2,49 @@ body {
   margin: 0;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
+.envelope-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+  overflow: hidden;
+  perspective: 1000px;
+}
+
+.envelope-wrapper {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+}
+
+.envelope-bottom {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.envelope-top {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  transform-origin: bottom center;
+  transition: transform 0.7s ease;
+}
+
+.envelope-stamp {
+  position: absolute;
+  width: 20vw;
+  max-width: 150px;
+  cursor: pointer;
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.envelope-overlay.opened .envelope-top {
+  transform: rotateX(180deg);
+}

--- a/Alondra_Website/src/App.jsx
+++ b/Alondra_Website/src/App.jsx
@@ -1,9 +1,16 @@
+import { useState } from 'react';
 import './App.css';
+import Envelope from './Envelope.jsx';
 
 function App() {
-    return (
+    const [open, setOpen] = useState(false);
 
-        <div className="min-h-screen bg-gradient-to-br from-pink-200 to-purple-300 flex flex-col items-center justify-center text-center p-6">
+    return (
+        <>
+            {!open && <Envelope onOpen={() => setOpen(true)} />}
+            <div
+                className={`min-h-screen bg-gradient-to-br from-pink-200 to-purple-300 flex flex-col items-center justify-center text-center p-6${open ? '' : ' opacity-0'}`}
+            >
             <h1 className="text-5xl font-bold mb-4">🎉 You're Invited! 🎉</h1>
             <h1 className="text-5xl text-red-600 font-bold">Tailwind is working!</h1>
 
@@ -24,7 +31,8 @@ function App() {
                     </button>
                 </form>
             </div>
-        </div>
+            </div>
+        </>
     );
 }
 

--- a/Alondra_Website/src/Envelope.jsx
+++ b/Alondra_Website/src/Envelope.jsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import stamp from './assets/Alondra_stamp.png';
+import topImg from './assets/alondra_sobre4.png';
+import bottomImg from './assets/alondra_sobre3.png';
+
+export default function Envelope({ onOpen }) {
+  const [opened, setOpened] = useState(false);
+
+  const handleClick = () => {
+    if (!opened) {
+      setOpened(true);
+      setTimeout(() => {
+        onOpen?.();
+      }, 700); // match CSS animation duration
+    }
+  };
+
+  return (
+    <div className={`envelope-overlay ${opened ? 'opened' : ''}`} onClick={handleClick}>
+      <div className="envelope-wrapper">
+        <img src={bottomImg} className="envelope-bottom" alt="envelope bottom" />
+        <img src={topImg} className="envelope-top" alt="envelope top" />
+        <img src={stamp} className="envelope-stamp" alt="stamp" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- adjust envelope CSS so it covers the entire screen
- rotate the flap upward during the open animation
- wrap envelope images inside a new `.envelope-wrapper`

## Testing
- `npm run lint`
- `npm run build`
- `npm run preview` *(terminated)*


------
https://chatgpt.com/codex/tasks/task_e_686b31c29a748333aca70d40632e9216