### PR TITLE
Create travel guide page and update venue details

### DIFF
--- a/Alondra_Website/src/App.jsx
+++ b/Alondra_Website/src/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import './App.css';
 import Envelope from './Envelope.jsx';
+import Travel from './Travel.jsx';
 
 const EVENT_DATE = new Date('2025-06-14T17:00:00-05:00');
 
@@ -56,6 +57,7 @@ function getTimeRemaining() {
 
 function App() {
     const [open, setOpen] = useState(false);
+    const [currentPage, setCurrentPage] = useState('home');
     const [timeLeft, setTimeLeft] = useState(() => getTimeRemaining());
 
     useEffect(() => {
@@ -80,314 +82,358 @@ function App() {
 
     return (
         <>
-            {!open && <Envelope onOpen={() => setOpen(true)} />}
+            {!open && (
+                <Envelope
+                    onOpen={() => {
+                        setOpen(true);
+                        setCurrentPage('home');
+                    }}
+                />
+            )}
             <div
                 className={`min-h-screen w-full bg-gradient-to-br from-rose-50 via-pink-50 to-amber-50 px-6 py-12 text-rose-900 transition-opacity duration-500 ease-out md:px-10 ${open ? 'opacity-100' : 'opacity-0'}`}
             >
-                <main className="mx-auto flex w-full max-w-6xl flex-col gap-20">
-                    <section className="text-center" id="home">
-                        <div className="flex justify-center">
-                            <span className="ribbon-tag">Mis XV • June 14, 2025</span>
-                        </div>
-                        <h1 className="font-display text-4xl md:text-6xl lg:text-7xl">
-                            Alondra&apos;s Quinceañera
-                        </h1>
-                        <p className="mt-4 text-lg text-rose-900/80 md:text-xl">
-                            Join us in celebrating fifteen beautiful years of faith, family, and dreams come true.
-                            Expect joyful traditions, delicious food, and a night of dancing beneath the stars.
-                        </p>
-                        <div className="mt-8 grid gap-4 md:grid-cols-3">
-                            <div className="glass-panel rounded-3xl p-6 text-left shadow-lg">
-                                <p className="text-sm uppercase tracking-[0.3em] text-rose-400">Date</p>
-                                <p className="mt-2 text-xl font-semibold">Saturday • June 14, 2025</p>
-                                <p className="text-rose-900/70">Ceremony begins promptly at 4:30 PM</p>
-                            </div>
-                            <div className="glass-panel rounded-3xl p-6 text-left shadow-lg">
-                                <p className="text-sm uppercase tracking-[0.3em] text-rose-400">Venue</p>
-                                <p className="mt-2 text-xl font-semibold">Villa Esperanza</p>
-                                <p className="text-rose-900/70">1234 Bloom Avenue • San Antonio, TX</p>
-                            </div>
-                            <div className="glass-panel rounded-3xl p-6 text-left shadow-lg">
-                                <p className="text-sm uppercase tracking-[0.3em] text-rose-400">Attire</p>
-                                <p className="mt-2 text-xl font-semibold">Evening Chic</p>
-                                <p className="text-rose-900/70">Dress in soft blush, champagne, or ivory accents.</p>
-                            </div>
-                        </div>
-                        <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
-                            <a
-                                href="#rsvp"
-                                className="rounded-full bg-rose-500 px-8 py-3 text-sm font-semibold uppercase tracking-widest text-white shadow-lg transition hover:bg-rose-600"
+                <header className="mx-auto flex w-full max-w-6xl flex-col gap-6 text-center sm:flex-row sm:items-center sm:justify-between">
+                    <div className="space-y-1">
+                        <p className="text-xs uppercase tracking-[0.5em] text-rose-400">Alondra Hernandez</p>
+                        <p className="font-display text-2xl text-rose-700">Mis XV Celebration</p>
+                    </div>
+                    <nav className="mx-auto flex w-full max-w-sm justify-center gap-2 rounded-full border border-rose-200/60 bg-white/70 p-1 shadow-lg sm:mx-0">
+                        {[
+                            { key: 'home', label: 'Home' },
+                            { key: 'travel', label: 'Travel Info' }
+                        ].map(({ key, label }) => (
+                            <button
+                                key={key}
+                                type="button"
+                                onClick={() => setCurrentPage(key)}
+                                className={`flex-1 rounded-full px-5 py-2 text-sm font-semibold uppercase tracking-[0.3em] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400 ${
+                                    currentPage === key
+                                        ? 'bg-rose-500 text-white shadow'
+                                        : 'text-rose-500 hover:bg-rose-50'
+                                }`}
+                                aria-pressed={currentPage === key}
                             >
-                                RSVP Now
-                            </a>
-                            <a
-                                href="#itinerary"
-                                className="rounded-full border border-rose-300/80 bg-white/80 px-8 py-3 text-sm font-semibold uppercase tracking-widest text-rose-500 shadow-lg transition hover:border-rose-400 hover:text-rose-600"
-                            >
-                                View Itinerary
-                            </a>
-                        </div>
-                    </section>
+                                {label}
+                            </button>
+                        ))}
+                    </nav>
+                </header>
+                {currentPage === 'home' ? (
+                    <main className="mx-auto mt-12 flex w-full max-w-6xl flex-col gap-20">
+                        <section className="text-center" id="home">
+                            <div className="flex justify-center">
+                                <span className="ribbon-tag">Mis XV • June 14, 2025</span>
+                            </div>
+                            <h1 className="font-display text-4xl md:text-6xl lg:text-7xl">
+                                Alondra&apos;s Quinceañera
+                            </h1>
+                            <p className="mt-4 text-lg text-rose-900/80 md:text-xl">
+                                Join us in celebrating fifteen beautiful years of faith, family, and dreams come true.
+                                Expect joyful traditions, delicious food, and a night of dancing beneath the stars.
+                            </p>
+                            <div className="mt-8 grid gap-4 md:grid-cols-3">
+                                <div className="glass-panel rounded-3xl p-6 text-left shadow-lg">
+                                    <p className="text-sm uppercase tracking-[0.3em] text-rose-400">Date</p>
+                                    <p className="mt-2 text-xl font-semibold">Saturday • June 14, 2025</p>
+                                    <p className="text-rose-900/70">Ceremony begins promptly at 4:30 PM</p>
+                                </div>
+                                <div className="glass-panel rounded-3xl p-6 text-left shadow-lg">
+                                    <p className="text-sm uppercase tracking-[0.3em] text-rose-400">Venue</p>
+                                    <p className="mt-2 text-xl font-semibold">The Pearl Stable</p>
+                                    <p className="text-rose-900/70">307 Pearl Pkwy • San Antonio, TX 78215</p>
+                                </div>
+                                <div className="glass-panel rounded-3xl p-6 text-left shadow-lg">
+                                    <p className="text-sm uppercase tracking-[0.3em] text-rose-400">Attire</p>
+                                    <p className="mt-2 text-xl font-semibold">Evening Chic</p>
+                                    <p className="text-rose-900/70">Dress in soft blush, champagne, or ivory accents.</p>
+                                </div>
+                            </div>
+                            <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
+                                <a
+                                    href="#rsvp"
+                                    className="rounded-full bg-rose-500 px-8 py-3 text-sm font-semibold uppercase tracking-widest text-white shadow-lg transition hover:bg-rose-600"
+                                >
+                                    RSVP Now
+                                </a>
+                                <a
+                                    href="#itinerary"
+                                    className="rounded-full border border-rose-300/80 bg-white/80 px-8 py-3 text-sm font-semibold uppercase tracking-widest text-rose-500 shadow-lg transition hover:border-rose-400 hover:text-rose-600"
+                                >
+                                    View Itinerary
+                                </a>
+                            </div>
+                        </section>
 
-                    <section className="glass-panel rounded-3xl p-8 text-center shadow-xl" id="countdown">
-                        <h2 className="font-display text-3xl md:text-4xl">Countdown to the Celebration</h2>
-                        <p className="mt-2 text-rose-900/70">We can&apos;t wait to celebrate with you!</p>
-                        {timeLeft.completed ? (
-                            <p className="mt-6 text-2xl font-semibold text-rose-500">It&apos;s party time! 💃🏽</p>
-                        ) : (
-                            <div className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
-                                {countdownUnits.map(({ label, value }) => (
-                                    <div
-                                        key={label}
-                                        className="rounded-2xl border border-rose-200 bg-white/70 px-6 py-6 shadow-md"
+                        <section className="glass-panel rounded-3xl p-8 text-center shadow-xl" id="countdown">
+                            <h2 className="font-display text-3xl md:text-4xl">Countdown to the Celebration</h2>
+                            <p className="mt-2 text-rose-900/70">We can&apos;t wait to celebrate with you!</p>
+                            {timeLeft.completed ? (
+                                <p className="mt-6 text-2xl font-semibold text-rose-500">It&apos;s party time! 💃🏽</p>
+                            ) : (
+                                <div className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
+                                    {countdownUnits.map(({ label, value }) => (
+                                        <div
+                                            key={label}
+                                            className="rounded-2xl border border-rose-200 bg-white/70 px-6 py-6 shadow-md"
+                                        >
+                                            <p className="text-4xl font-bold text-rose-500 md:text-5xl">{String(value).padStart(2, '0')}</p>
+                                            <p className="mt-2 text-xs uppercase tracking-[0.4em] text-rose-400">{label}</p>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </section>
+
+                        <section id="details" className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+                            <div className="glass-panel rounded-3xl p-8 shadow-xl">
+                                <h2 className="font-display text-3xl">Event Highlights</h2>
+                                <p className="mt-3 text-rose-900/80">
+                                    From the traditional mass to a sparkling reception, every detail has been planned with
+                                    family and friends in mind. Take a peek at the evening&apos;s highlights and make sure you
+                                    arrive in time for the ceremonies that matter most to Alondra and her parents.
+                                </p>
+                                <ul className="mt-6 space-y-4 text-left">
+                                    <li className="flex items-start gap-3">
+                                        <span className="mt-1 inline-flex h-3 w-3 flex-none rounded-full bg-rose-400"></span>
+                                        <div>
+                                            <h3 className="text-lg font-semibold">Courtside Moments</h3>
+                                            <p className="text-rose-900/70">
+                                                Celebrate with Alondra&apos;s court of damas and chambelanes during the surprise dance and
+                                                a special toast from her padrinos.
+                                            </p>
+                                        </div>
+                                    </li>
+                                    <li className="flex items-start gap-3">
+                                        <span className="mt-1 inline-flex h-3 w-3 flex-none rounded-full bg-rose-400"></span>
+                                        <div>
+                                            <h3 className="text-lg font-semibold">Sweet Indulgences</h3>
+                                            <p className="text-rose-900/70">
+                                                Enjoy a dessert bar inspired by Alondra&apos;s favorite flavors plus a late-night churro cart for
+                                                guests who stay on the dance floor.
+                                            </p>
+                                        </div>
+                                    </li>
+                                    <li className="flex items-start gap-3">
+                                        <span className="mt-1 inline-flex h-3 w-3 flex-none rounded-full bg-rose-400"></span>
+                                        <div>
+                                            <h3 className="text-lg font-semibold">Music & Memories</h3>
+                                            <p className="text-rose-900/70">
+                                                Our curated Spotify playlist sets the mood—be sure to hit play when you arrive and share your
+                                                song requests with the DJ booth.
+                                            </p>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+                            <aside className="glass-panel flex flex-col justify-between rounded-3xl p-8 text-center shadow-xl">
+                                <div>
+                                    <p className="font-script text-3xl text-rose-500">Con mucho amor</p>
+                                    <p className="mt-2 text-rose-900/70">
+                                        Hosted by the Hernandez family • Madrina: Sofia Ruiz • Padrino: Alejandro Torres
+                                    </p>
+                                </div>
+                                <div className="mt-8 space-y-3 text-rose-900/70">
+                                    <p>Need to update your RSVP or have dietary restrictions?</p>
+                                    <a
+                                        href="mailto:celebrate@alondrasxv.com"
+                                        className="font-semibold text-rose-500 underline-offset-4 hover:underline"
                                     >
-                                        <p className="text-4xl font-bold text-rose-500 md:text-5xl">{String(value).padStart(2, '0')}</p>
-                                        <p className="mt-2 text-xs uppercase tracking-[0.4em] text-rose-400">{label}</p>
+                                        celebrate@alondrasxv.com
+                                    </a>
+                                    <p className="text-sm">We&apos;re happy to help you plan your perfect evening.</p>
+                                </div>
+                            </aside>
+                        </section>
+
+                        <section id="itinerary" className="glass-panel rounded-3xl p-8 shadow-xl">
+                            <div className="flex flex-col items-start justify-between gap-6 md:flex-row">
+                                <div>
+                                    <h2 className="font-display text-3xl">Evening Schedule</h2>
+                                    <p className="mt-2 max-w-2xl text-rose-900/75">
+                                        We&apos;ve curated the night so you won&apos;t miss a single tradition. Arrive a little early to snap
+                                        photos by the floral wall and sign Alondra&apos;s guestbook.
+                                    </p>
+                                </div>
+                                <a
+                                    href="https://calendar.google.com"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="rounded-full border border-rose-300 bg-white/80 px-6 py-2 text-sm font-semibold uppercase tracking-widest text-rose-500 shadow transition hover:border-rose-400 hover:text-rose-600"
+                                >
+                                    Save to Calendar
+                                </a>
+                            </div>
+                            <div className="mt-8 grid gap-6 md:grid-cols-2">
+                                {ITINERARY.map((event) => (
+                                    <div key={event.title} className="rounded-3xl border border-rose-100 bg-white/80 p-6 shadow-md">
+                                        <p className="text-sm uppercase tracking-[0.3em] text-rose-400">{event.time}</p>
+                                        <h3 className="mt-2 text-xl font-semibold text-rose-600">{event.title}</h3>
+                                        <p className="mt-2 text-rose-900/70">{event.description}</p>
                                     </div>
                                 ))}
                             </div>
-                        )}
-                    </section>
+                        </section>
 
-                    <section id="details" className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
-                        <div className="glass-panel rounded-3xl p-8 shadow-xl">
-                            <h2 className="font-display text-3xl">Event Highlights</h2>
-                            <p className="mt-3 text-rose-900/80">
-                                From the traditional mass to a sparkling reception, every detail has been planned with
-                                family and friends in mind. Take a peek at the evening&apos;s highlights and make sure you
-                                arrive in time for the ceremonies that matter most to Alondra and her parents.
-                            </p>
-                            <ul className="mt-6 space-y-4 text-left">
-                                <li className="flex items-start gap-3">
-                                    <span className="mt-1 inline-flex h-3 w-3 flex-none rounded-full bg-rose-400"></span>
-                                    <div>
-                                        <h3 className="text-lg font-semibold">Courtside Moments</h3>
-                                        <p className="text-rose-900/70">
-                                            Celebrate with Alondra&apos;s court of damas and chambelanes during the surprise dance and
-                                            a special toast from her padrinos.
-                                        </p>
-                                    </div>
-                                </li>
-                                <li className="flex items-start gap-3">
-                                    <span className="mt-1 inline-flex h-3 w-3 flex-none rounded-full bg-rose-400"></span>
-                                    <div>
-                                        <h3 className="text-lg font-semibold">Sweet Indulgences</h3>
-                                        <p className="text-rose-900/70">
-                                            Enjoy a dessert bar inspired by Alondra&apos;s favorite flavors plus a late-night churro cart for
-                                            guests who stay on the dance floor.
-                                        </p>
-                                    </div>
-                                </li>
-                                <li className="flex items-start gap-3">
-                                    <span className="mt-1 inline-flex h-3 w-3 flex-none rounded-full bg-rose-400"></span>
-                                    <div>
-                                        <h3 className="text-lg font-semibold">Music & Memories</h3>
-                                        <p className="text-rose-900/70">
-                                            Our curated Spotify playlist sets the mood—be sure to hit play when you arrive and share your
-                                            song requests with the DJ booth.
-                                        </p>
-                                    </div>
-                                </li>
-                            </ul>
-                        </div>
-                        <aside className="glass-panel flex flex-col justify-between rounded-3xl p-8 text-center shadow-xl">
-                            <div>
-                                <p className="font-script text-3xl text-rose-500">Con mucho amor</p>
-                                <p className="mt-2 text-rose-900/70">
-                                    Hosted by the Hernandez family • Madrina: Sofia Ruiz • Padrino: Alejandro Torres
+                        <section id="location" className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+                            <div className="glass-panel rounded-3xl p-8 shadow-xl">
+                                <h2 className="font-display text-3xl">Getting There</h2>
+                                <p className="mt-2 text-rose-900/75">
+                                    The Pearl Stable sits in the heart of San Antonio&apos;s Pearl District. Complimentary valet begins at
+                                    3:45 PM, and self-parking is available in the Koehler Garage across the street.
                                 </p>
-                            </div>
-                            <div className="mt-8 space-y-3 text-rose-900/70">
-                                <p>Need to update your RSVP or have dietary restrictions?</p>
-                                <a
-                                    href="mailto:celebrate@alondrasxv.com"
-                                    className="font-semibold text-rose-500 underline-offset-4 hover:underline"
-                                >
-                                    celebrate@alondrasxv.com
-                                </a>
-                                <p className="text-sm">We&apos;re happy to help you plan your perfect evening.</p>
-                            </div>
-                        </aside>
-                    </section>
-
-                    <section id="itinerary" className="glass-panel rounded-3xl p-8 shadow-xl">
-                        <div className="flex flex-col items-start justify-between gap-6 md:flex-row">
-                            <div>
-                                <h2 className="font-display text-3xl">Evening Schedule</h2>
-                                <p className="mt-2 max-w-2xl text-rose-900/75">
-                                    We&apos;ve curated the night so you won&apos;t miss a single tradition. Arrive a little early to snap
-                                    photos by the floral wall and sign Alondra&apos;s guestbook.
-                                </p>
-                            </div>
-                            <a
-                                href="https://calendar.google.com"
-                                target="_blank"
-                                rel="noreferrer"
-                                className="rounded-full border border-rose-300 bg-white/80 px-6 py-2 text-sm font-semibold uppercase tracking-widest text-rose-500 shadow transition hover:border-rose-400 hover:text-rose-600"
-                            >
-                                Save to Calendar
-                            </a>
-                        </div>
-                        <div className="mt-8 grid gap-6 md:grid-cols-2">
-                            {ITINERARY.map((event) => (
-                                <div key={event.title} className="rounded-3xl border border-rose-100 bg-white/80 p-6 shadow-md">
-                                    <p className="text-sm uppercase tracking-[0.3em] text-rose-400">{event.time}</p>
-                                    <h3 className="mt-2 text-xl font-semibold text-rose-600">{event.title}</h3>
-                                    <p className="mt-2 text-rose-900/70">{event.description}</p>
-                                </div>
-                            ))}
-                        </div>
-                    </section>
-
-                    <section id="location" className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-                        <div className="glass-panel rounded-3xl p-8 shadow-xl">
-                            <h2 className="font-display text-3xl">Getting There</h2>
-                            <p className="mt-2 text-rose-900/75">
-                                Villa Esperanza is just 15 minutes from downtown San Antonio. Complimentary valet parking will
-                                be available, and rideshare drop-off is at the main fountain entrance.
-                            </p>
-                            <ul className="mt-6 space-y-3 text-rose-900/70">
-                                <li>
-                                    <span className="font-semibold text-rose-600">Hotel Block:</span> Courtyard Alondra • Ask for the
-                                    &ldquo;Mis XV&rdquo; rate by May 20.
-                                </li>
-                                <li>
-                                    <span className="font-semibold text-rose-600">Travel Tip:</span> Out-of-town guests, arrive by
-                                    Friday for the welcome tamalada hosted at Abuela&apos;s home.
-                                </li>
-                                <li>
-                                    <span className="font-semibold text-rose-600">Need a ride?</span> Contact our transportation team at
-                                    <a
-                                        href="tel:2105550199"
-                                        className="ml-1 font-semibold text-rose-500 underline-offset-4 hover:underline"
-                                    >
-                                        (210) 555-0199
-                                    </a>
-                                    .
-                                </li>
-                            </ul>
-                        </div>
-                        <div className="overflow-hidden rounded-3xl shadow-xl">
-                            <iframe
-                                title="Villa Esperanza Map"
-                                src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d110509.53228473353!2d-98.61068955!3d29.4246007!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x865cf51d1c91668d%3A0xe8300c93450ccaa3!2sSan%20Antonio%2C%20TX!5e0!3m2!1sen!2sus!4v1700000000000!5m2!1sen!2sus"
-                                className="h-full min-h-[320px] w-full border-0"
-                                loading="lazy"
-                                referrerPolicy="no-referrer-when-downgrade"
-                                allowFullScreen
-                            ></iframe>
-                        </div>
-                    </section>
-
-                    <section id="registry" className="glass-panel rounded-3xl p-8 shadow-xl">
-                        <h2 className="font-display text-3xl text-center">Gifts & Blessings</h2>
-                        <p className="mt-3 text-center text-rose-900/75">
-                            Your presence is the greatest gift! If you&apos;d like to contribute to Alondra&apos;s college dreams or
-                            share a keepsake, explore the options below.
-                        </p>
-                        <div className="mt-8 flex flex-wrap justify-center gap-4">
-                            <a
-                                href="https://www.paypal.com/"
-                                target="_blank"
-                                rel="noreferrer"
-                                className="rounded-full bg-rose-500 px-8 py-3 text-sm font-semibold uppercase tracking-widest text-white shadow-lg transition hover:bg-rose-600"
-                            >
-                                Contribute via PayPal
-                            </a>
-                            <a
-                                href="https://www.amazon.com/wedding"
-                                target="_blank"
-                                rel="noreferrer"
-                                className="rounded-full border border-rose-300/80 bg-white/80 px-8 py-3 text-sm font-semibold uppercase tracking-widest text-rose-500 shadow-lg transition hover:border-rose-400 hover:text-rose-600"
-                            >
-                                View Amazon Registry
-                            </a>
-                            <a
-                                href="https://www.honeyfund.com/"
-                                target="_blank"
-                                rel="noreferrer"
-                                className="rounded-full border border-rose-300/80 bg-white/80 px-8 py-3 text-sm font-semibold uppercase tracking-widest text-rose-500 shadow-lg transition hover:border-rose-400 hover:text-rose-600"
-                            >
-                                Honeyfund Experiences
-                            </a>
-                        </div>
-                    </section>
-
-                    <section id="rsvp" className="glass-panel rounded-3xl p-8 shadow-xl">
-                        <div className="grid gap-8 md:grid-cols-2">
-                            <div>
-                                <h2 className="font-display text-3xl">RSVP by May 20</h2>
-                                <p className="mt-3 text-rose-900/75">
-                                    We can&apos;t wait to celebrate with you! Let us know who&apos;s coming so we can reserve your seats,
-                                    accommodate special requests, and prepare your welcome favors.
-                                </p>
-                                <ul className="mt-4 space-y-2 text-rose-900/70">
-                                    <li>✨ Kindly respond for each guest in your party.</li>
-                                    <li>🥗 Vegetarian or gluten-free meals available upon request.</li>
-                                    <li>🎶 Add your favorite song—our DJ is taking requests!</li>
+                                <ul className="mt-6 space-y-3 text-rose-900/70">
+                                    <li>
+                                        <span className="font-semibold text-rose-600">Hotel Block:</span> Reserve under &ldquo;Alondra&apos;s
+                                        Mis XV&rdquo; at Hotel Emma or the Pearl Canopy by May 20.
+                                    </li>
+                                    <li>
+                                        <span className="font-semibold text-rose-600">Travel Tip:</span> Fly into SAT (15 minutes away) or
+                                        Austin-Bergstrom (75 minutes) and head straight to the Pearl for welcome cafecito.
+                                    </li>
+                                    <li>
+                                        <span className="font-semibold text-rose-600">Need a ride?</span> Contact our transportation team at
+                                        <a
+                                            href="tel:2105550199"
+                                            className="ml-1 font-semibold text-rose-500 underline-offset-4 hover:underline"
+                                        >
+                                            (210) 555-0199
+                                        </a>
+                                        .
+                                    </li>
                                 </ul>
-                            </div>
-                            <form
-                                className="rounded-3xl border border-rose-100 bg-white/80 p-6 shadow-md"
-                                action="https://forms.gle/"
-                                method="post"
-                                target="_blank"
-                            >
-                                <div className="grid gap-4">
-                                    <input
-                                        type="text"
-                                        name="name"
-                                        placeholder="Your Full Name"
-                                        required
-                                        className="rounded-full border border-rose-200 bg-white/90 px-4 py-3 text-sm focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-200"
-                                    />
-                                    <input
-                                        type="email"
-                                        name="email"
-                                        placeholder="Email Address"
-                                        required
-                                        className="rounded-full border border-rose-200 bg-white/90 px-4 py-3 text-sm focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-200"
-                                    />
-                                    <input
-                                        type="tel"
-                                        name="phone"
-                                        placeholder="Phone Number"
-                                        className="rounded-full border border-rose-200 bg-white/90 px-4 py-3 text-sm focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-200"
-                                    />
-                                    <select
-                                        name="attendance"
-                                        required
-                                        className="rounded-full border border-rose-200 bg-white/90 px-4 py-3 text-sm text-rose-900 focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-200"
-                                    >
-                                        <option value="">Will you celebrate with us?</option>
-                                        <option value="yes">Sí, can&apos;t wait!</option>
-                                        <option value="no">Sadly, unable to attend</option>
-                                    </select>
-                                    <textarea
-                                        name="message"
-                                        rows="3"
-                                        placeholder="Share a note or song request"
-                                        className="rounded-3xl border border-rose-200 bg-white/90 px-4 py-3 text-sm focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-200"
-                                    ></textarea>
+                                <div className="mt-6">
                                     <button
-                                        type="submit"
-                                        className="rounded-full bg-rose-500 px-8 py-3 text-sm font-semibold uppercase tracking-widest text-white shadow-lg transition hover:bg-rose-600"
+                                        type="button"
+                                        onClick={() => setCurrentPage('travel')}
+                                        className="rounded-full border border-rose-300 bg-white/80 px-6 py-2 text-sm font-semibold uppercase tracking-widest text-rose-500 shadow transition hover:border-rose-400 hover:text-rose-600"
                                     >
-                                        Submit RSVP
+                                        View Full Travel Guide
                                     </button>
                                 </div>
-                                <p className="mt-4 text-xs text-rose-400">
-                                    This form opens a secure RSVP in a new tab so you can attach additional guests or messages.
-                                </p>
-                            </form>
-                        </div>
-                    </section>
-                </main>
+                            </div>
+                            <div className="overflow-hidden rounded-3xl shadow-xl">
+                                <iframe
+                                    title="The Pearl Stable Map"
+                                    src="https://maps.google.com/maps?q=307%20Pearl%20Pkwy%2C%20San%20Antonio%2C%20TX%2078215&t=&z=15&ie=UTF8&iwloc=&output=embed"
+                                    className="h-full min-h-[320px] w-full border-0"
+                                    loading="lazy"
+                                    referrerPolicy="no-referrer-when-downgrade"
+                                    allowFullScreen
+                                ></iframe>
+                            </div>
+                        </section>
 
-                <footer className="mt-20 border-t border-rose-200/60 pt-6 text-center text-sm text-rose-900/60">
-                    <p>
-                        Made with ♥ for Alondra&apos;s quinceañera. See you on the dance floor!
-                    </p>
+                        <section id="registry" className="glass-panel rounded-3xl p-8 shadow-xl">
+                            <h2 className="font-display text-3xl text-center">Gifts & Blessings</h2>
+                            <p className="mt-3 text-center text-rose-900/75">
+                                Your presence is the greatest gift! If you&apos;d like to contribute to Alondra&apos;s college dreams or
+                                share a keepsake, explore the options below.
+                            </p>
+                            <div className="mt-8 flex flex-wrap justify-center gap-4">
+                                <a
+                                    href="https://www.paypal.com/"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="rounded-full bg-rose-500 px-8 py-3 text-sm font-semibold uppercase tracking-widest text-white shadow-lg transition hover:bg-rose-600"
+                                >
+                                    Contribute via PayPal
+                                </a>
+                                <a
+                                    href="https://www.amazon.com/wedding"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="rounded-full border border-rose-300/80 bg-white/80 px-8 py-3 text-sm font-semibold uppercase tracking-widest text-rose-500 shadow-lg transition hover:border-rose-400 hover:text-rose-600"
+                                >
+                                    View Amazon Registry
+                                </a>
+                                <a
+                                    href="https://www.honeyfund.com/"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="rounded-full border border-rose-300/80 bg-white/80 px-8 py-3 text-sm font-semibold uppercase tracking-widest text-rose-500 shadow-lg transition hover:border-rose-400 hover:text-rose-600"
+                                >
+                                    Honeyfund Experiences
+                                </a>
+                            </div>
+                        </section>
+
+                        <section id="rsvp" className="glass-panel rounded-3xl p-8 shadow-xl">
+                            <div className="grid gap-8 md:grid-cols-2">
+                                <div>
+                                    <h2 className="font-display text-3xl">RSVP by May 20</h2>
+                                    <p className="mt-3 text-rose-900/75">
+                                        We can&apos;t wait to celebrate with you! Let us know who&apos;s coming so we can reserve your seats,
+                                        accommodate special requests, and prepare your welcome favors.
+                                    </p>
+                                    <ul className="mt-4 space-y-2 text-rose-900/70">
+                                        <li>✨ Kindly respond for each guest in your party.</li>
+                                        <li>🥗 Vegetarian or gluten-free meals available upon request.</li>
+                                        <li>🎶 Add your favorite song—our DJ is taking requests!</li>
+                                    </ul>
+                                </div>
+                                <form
+                                    className="rounded-3xl border border-rose-100 bg-white/80 p-6 shadow-md"
+                                    action="https://forms.gle/"
+                                    method="post"
+                                    target="_blank"
+                                >
+                                    <div className="grid gap-4">
+                                        <input
+                                            type="text"
+                                            name="name"
+                                            placeholder="Your Full Name"
+                                            required
+                                            className="rounded-full border border-rose-200 bg-white/90 px-4 py-3 text-sm focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-200"
+                                        />
+                                        <input
+                                            type="email"
+                                            name="email"
+                                            placeholder="Email Address"
+                                            required
+                                            className="rounded-full border border-rose-200 bg-white/90 px-4 py-3 text-sm focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-200"
+                                        />
+                                        <input
+                                            type="tel"
+                                            name="phone"
+                                            placeholder="Phone Number"
+                                            className="rounded-full border border-rose-200 bg-white/90 px-4 py-3 text-sm focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-200"
+                                        />
+                                        <select
+                                            name="attendance"
+                                            required
+                                            className="rounded-full border border-rose-200 bg-white/90 px-4 py-3 text-sm text-rose-900 focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-200"
+                                        >
+                                            <option value="">Will you celebrate with us?</option>
+                                            <option value="yes">Sí, can&apos;t wait!</option>
+                                            <option value="no">Sadly, unable to attend</option>
+                                        </select>
+                                        <textarea
+                                            name="message"
+                                            rows="3"
+                                            placeholder="Share a note or song request"
+                                            className="rounded-3xl border border-rose-200 bg-white/90 px-4 py-3 text-sm focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-200"
+                                        ></textarea>
+                                        <button
+                                            type="submit"
+                                            className="rounded-full bg-rose-500 px-8 py-3 text-sm font-semibold uppercase tracking-widest text-white shadow-lg transition hover:bg-rose-600"
+                                        >
+                                            Submit RSVP
+                                        </button>
+                                    </div>
+                                    <p className="mt-4 text-xs text-rose-400">
+                                        This form opens a secure RSVP in a new tab so you can attach additional guests or messages.
+                                    </p>
+                                </form>
+                            </div>
+                        </section>
+                </main>
+                ) : (
+                    <Travel />
+                )}
+
+                <footer className="mx-auto mt-20 w-full max-w-6xl border-t border-rose-200/60 pt-6 text-center text-sm text-rose-900/60">
+                    <p>Made with ♥ for Alondra&apos;s quinceañera. See you on the dance floor!</p>
                 </footer>
             </div>
         </>

--- a/Alondra_Website/src/App.jsx
+++ b/Alondra_Website/src/App.jsx
@@ -140,8 +140,8 @@ function App() {
                                 </div>
                                 <div className="glass-panel rounded-3xl p-6 text-left shadow-lg">
                                     <p className="text-sm uppercase tracking-[0.3em] text-rose-400">Venue</p>
-                                    <p className="mt-2 text-xl font-semibold">The Pearl Stable</p>
-                                    <p className="text-rose-900/70">307 Pearl Pkwy • San Antonio, TX 78215</p>
+                                    <p className="mt-2 text-xl font-semibold">Rincón of the Seas Grand Caribbean Hotel &amp; Villa</p>
+                                    <p className="text-rose-900/70">Road 115 KM 12.2 • Rincón, Puerto Rico</p>
                                 </div>
                                 <div className="glass-panel rounded-3xl p-6 text-left shadow-lg">
                                     <p className="text-sm uppercase tracking-[0.3em] text-rose-400">Attire</p>
@@ -279,27 +279,39 @@ function App() {
                             <div className="glass-panel rounded-3xl p-8 shadow-xl">
                                 <h2 className="font-display text-3xl">Getting There</h2>
                                 <p className="mt-2 text-rose-900/75">
-                                    The Pearl Stable sits in the heart of San Antonio&apos;s Pearl District. Complimentary valet begins at
-                                    3:45 PM, and self-parking is available in the Koehler Garage across the street.
+                                    Rincón of the Seas Grand Caribbean Hotel &amp; Villa is nestled along Puerto Rico&apos;s west coast. Guests
+                                    staying on-site can coordinate with the reservation team ahead of the celebration to secure their stay
+                                    just steps from the oceanfront ballroom.
                                 </p>
                                 <ul className="mt-6 space-y-3 text-rose-900/70">
                                     <li>
-                                        <span className="font-semibold text-rose-600">Hotel Block:</span> Reserve under &ldquo;Alondra&apos;s
-                                        Mis XV&rdquo; at Hotel Emma or the Pearl Canopy by May 20.
-                                    </li>
-                                    <li>
-                                        <span className="font-semibold text-rose-600">Travel Tip:</span> Fly into SAT (15 minutes away) or
-                                        Austin-Bergstrom (75 minutes) and head straight to the Pearl for welcome cafecito.
-                                    </li>
-                                    <li>
-                                        <span className="font-semibold text-rose-600">Need a ride?</span> Contact our transportation team at
+                                        <span className="font-semibold text-rose-600">Hotel Block:</span> Reference &ldquo;Quinceañera Alondra&rdquo;
+                                        with reservation code 334 when booking directly with the hotel. Call
                                         <a
-                                            href="tel:2105550199"
+                                            href="tel:7878237500"
                                             className="ml-1 font-semibold text-rose-500 underline-offset-4 hover:underline"
                                         >
-                                            (210) 555-0199
+                                            (787) 823-7500
                                         </a>
-                                        .
+                                        or contact Lisandra Ayala at
+                                        <a
+                                            href="tel:7878238114"
+                                            className="ml-1 font-semibold text-rose-500 underline-offset-4 hover:underline"
+                                        >
+                                            (787) 823-8114
+                                        </a>
+                                        for assistance. A one-night deposit is required.
+                                    </li>
+                                    <li>
+                                        <span className="font-semibold text-rose-600">Travel Tip:</span> Aguadilla Airport (BQN) is roughly
+                                        40 minutes from the hotel, while San Juan Airport (SJU) averages about 2 hours and 20 minutes,
+                                        subject to traffic.
+                                    </li>
+                                    <li>
+                                        <span className="font-semibold text-rose-600">Need a ride?</span> From SJU call Wilbert Taxis
+                                        (787-479-9767), Puerto Rico Taxi (787-685-9666), or Taxi PR Carolina (787-513-5916). From BQN reach
+                                        Aguadilla Taxi (787-318-9546), Aguadilla Borinquen Taxis (787-431-8179), or Manny&apos;s Taxis
+                                        (939-366-2214). Uber is also available throughout Puerto Rico.
                                     </li>
                                 </ul>
                                 <div className="mt-6">
@@ -314,8 +326,8 @@ function App() {
                             </div>
                             <div className="overflow-hidden rounded-3xl shadow-xl">
                                 <iframe
-                                    title="The Pearl Stable Map"
-                                    src="https://maps.google.com/maps?q=307%20Pearl%20Pkwy%2C%20San%20Antonio%2C%20TX%2078215&t=&z=15&ie=UTF8&iwloc=&output=embed"
+                                    title="Rincón of the Seas Grand Caribbean Hotel &amp; Villa Map"
+                                    src="https://maps.google.com/maps?q=Rinc%C3%B3n%20of%20the%20Seas%20Grand%20Caribbean%20Hotel%20%26%20Villa&t=&z=15&ie=UTF8&iwloc=&output=embed"
                                     className="h-full min-h-[320px] w-full border-0"
                                     loading="lazy"
                                     referrerPolicy="no-referrer-when-downgrade"

--- a/Alondra_Website/src/Travel.jsx
+++ b/Alondra_Website/src/Travel.jsx
@@ -1,49 +1,62 @@
 import './App.css';
 
-const VENUE_ADDRESS = '307 Pearl Pkwy, San Antonio, TX 78215';
+const VENUE_NAME = 'Rincón of the Seas Grand Caribbean Hotel & Villa';
+const VENUE_ADDRESS = 'Road 115 KM 12.2, Rincón, Puerto Rico';
 
 const HOTELS = [
     {
-        name: 'Hotel Emma',
-        distance: 'On-site at Pearl District',
+        name: VENUE_NAME,
+        distance: 'On-site accommodations at the venue',
         description:
-            'Luxury accommodations with historic charm. Request the “Alondra Mis XV” rate for welcome bag delivery and late checkout.',
-        perks: ['Complimentary welcome paletas', 'Access to rooftop pool', '2-minute walk to The Pearl Stable']
-    },
-    {
-        name: 'Canopy by Hilton San Antonio Riverwalk',
-        distance: '0.6 miles from venue',
-        description:
-            'Trendy riverside stay with easy access to the River Walk. Mention the quinceañera room block for discounted valet parking.',
-        perks: ['Breakfast vouchers included', 'River Walk views', 'Shuttle to the venue at 3:45 PM']
+            'Stay where the celebration takes place and enjoy ocean views, resort amenities, and effortless access to every event.',
+        perks: [
+            'Reference reservation code 334 and “Quinceañera Alondra” when booking',
+            'One-night deposit required to confirm your stay',
+            'Book directly with the hotel team — online reservations are not yet available'
+        ]
     }
 ];
 
 const AIRPORTS = [
     {
-        code: 'SAT',
-        name: 'San Antonio International Airport',
-        details: 'Closest airport with nonstop flights nationwide. 15-minute rideshare to the Pearl District.'
+        code: 'BQN',
+        name: 'Aguadilla, PR (BQN)',
+        details:
+            'Closest airport to the venue with regional flights. Approximate travel time to Rincón of the Seas: ~40 minutes (subject to traffic).'
     },
     {
-        code: 'AUS',
-        name: 'Austin-Bergstrom International Airport',
-        details: 'A scenic 75-minute drive south. Perfect for guests extending their Texas getaway.'
+        code: 'SJU',
+        name: 'San Juan, PR (SJU)',
+        details:
+            'Major international hub with plentiful flight options. Approximate travel time to the hotel: ~2 hours 20 minutes (subject to traffic).'
     }
 ];
 
+const TAXI_SERVICES = {
+    sju: [
+        { name: 'Wilbert Taxis', phone: '787-479-9767' },
+        { name: 'Puerto Rico Taxi', phone: '787-685-9666' },
+        { name: 'Taxi PR Carolina', phone: '787-513-5916' }
+    ],
+    bqn: [
+        { name: 'Aguadilla Taxi', phone: '787-318-9546' },
+        { name: 'Aguadilla Borinquen Taxis', phone: '787-431-8179' },
+        { name: "Manny's Taxis", phone: '939-366-2214' }
+    ]
+};
+
 const LOCAL_TIPS = [
     {
-        title: 'Parking & Arrival',
-        body: 'Complimentary valet begins at 3:45 PM at The Pearl Stable porte-cochère. Self-parking is available in the Koehler Garage (map pins provided below).'
+        title: 'Check-In Details',
+        body: 'Call the reservations team ahead of arrival to confirm your deposit and room assignment. Early check-in is based on availability.'
     },
     {
-        title: 'Welcome Gatherings',
-        body: 'Join us Friday evening at Larder inside Hotel Emma for cafecito and conchas from 7:00 – 9:00 PM.'
+        title: 'Beach Time',
+        body: 'Pack beachwear for downtime—Steps Beach and Balneario de Rincón are minutes from the hotel.'
     },
     {
-        title: 'Sunday Brunch',
-        body: 'Meet the family at Bakery Lorraine Pearl for a casual send-off brunch beginning at 10:30 AM.'
+        title: 'Sunset Tradition',
+        body: 'Gather with family on the hotel grounds for a sunset photo session overlooking the Caribbean Sea.'
     }
 ];
 
@@ -52,29 +65,63 @@ export default function Travel() {
         <main className="mx-auto mt-12 flex w-full max-w-6xl flex-col gap-14">
             <section className="glass-panel rounded-3xl p-8 shadow-xl">
                 <span className="ribbon-tag">Travel Guide</span>
-                <h1 className="mt-4 font-display text-4xl">Plan Your Stay in San Antonio</h1>
+                <h1 className="mt-4 font-display text-4xl">Plan Your Stay in Rincón, Puerto Rico</h1>
                 <p className="mt-3 max-w-3xl text-rose-900/75">
-                    The celebration takes place at <strong>The Pearl Stable</strong>, located at {VENUE_ADDRESS}. Arrive by 4:00 PM to
-                    enjoy welcome refreshments and snap photos around the iconic Pearl grounds before the mass begins.
+                    The celebration takes place at <strong>{VENUE_NAME}</strong>, located at {VENUE_ADDRESS}. Please arrive with enough
+                    time to soak in the coastal views, enjoy a welcome refreshment, and prepare for the ceremony to begin at 4:30 PM.
                 </p>
                 <div className="mt-8 grid gap-6 md:grid-cols-2">
                     <div className="rounded-3xl border border-rose-100 bg-white/80 p-6 shadow-md">
-                        <h2 className="text-lg font-semibold text-rose-600">Venue Address</h2>
-                        <p className="mt-2 text-rose-900/75">The Pearl Stable</p>
+                        <h2 className="text-lg font-semibold text-rose-600">Venue Details</h2>
+                        <p className="mt-2 text-rose-900/75">{VENUE_NAME}</p>
                         <p className="text-rose-900/60">{VENUE_ADDRESS}</p>
-                        <p className="mt-4 text-sm text-rose-900/60">
-                            Doors open at 3:45 PM for guest seating. Ceremony begins promptly at 4:30 PM with reception to follow.
-                        </p>
+                        <ul className="mt-4 space-y-2 text-sm text-rose-900/60">
+                            <li>
+                                <strong>Reservation Code:</strong> 334 (reference “Quinceañera Alondra”)
+                            </li>
+                            <li>
+                                <strong>Front Desk:</strong>{' '}
+                                <a className="font-semibold text-rose-500 underline-offset-4 hover:underline" href="tel:7878237500">
+                                    (787) 823-7500
+                                </a>
+                            </li>
+                            <li>
+                                <strong>Contact:</strong>{' '}
+                                <a className="font-semibold text-rose-500 underline-offset-4 hover:underline" href="tel:7878238114">
+                                    Lisandra Ayala (787) 823-8114
+                                </a>
+                            </li>
+                            <li>
+                                <strong>Email:</strong>{' '}
+                                <a className="font-semibold text-rose-500 underline-offset-4 hover:underline" href="mailto:LA@RINCONOFTHESEAS.COM">
+                                    LA@RINCONOFTHESEAS.COM
+                                </a>
+                            </li>
+                            <li>Online reservations are not yet available; please book directly. A one-night deposit is required.</li>
+                        </ul>
                     </div>
                     <div className="rounded-3xl border border-rose-100 bg-white/80 p-6 shadow-md">
                         <h2 className="text-lg font-semibold text-rose-600">Weekend Snapshot</h2>
                         <ul className="mt-3 space-y-2 text-sm text-rose-900/70">
-                            <li><strong>Friday:</strong> Welcome cafecito at Larder (7:00 PM)</li>
-                            <li><strong>Saturday:</strong> Ceremony & reception at The Pearl Stable (4:30 PM)</li>
-                            <li><strong>Sunday:</strong> Farewell brunch at Bakery Lorraine (10:30 AM)</li>
+                            <li>
+                                <strong>Friday:</strong> Arrivals and casual meet-up at the hotel lobby lounge (from 7:00 PM)
+                            </li>
+                            <li>
+                                <strong>Saturday:</strong> Ceremony & reception at {VENUE_NAME} (doors open 3:45 PM)
+                            </li>
+                            <li>
+                                <strong>Sunday:</strong> Beachside farewell breakfast on property (10:30 AM)
+                            </li>
                         </ul>
                         <p className="mt-4 text-sm text-rose-900/60">
-                            Need assistance during the weekend? Text our hostess team at <a className="font-semibold text-rose-500 underline-offset-4 hover:underline" href="tel:2105550199">(210) 555-0199</a>.
+                            Need assistance during the weekend? Email
+                            <a
+                                className="ml-1 font-semibold text-rose-500 underline-offset-4 hover:underline"
+                                href="mailto:LA@RINCONOFTHESEAS.COM"
+                            >
+                                LA@RINCONOFTHESEAS.COM
+                            </a>
+                            or call the hotel team directly.
                         </p>
                     </div>
                 </div>
@@ -84,8 +131,8 @@ export default function Travel() {
                 <div className="glass-panel rounded-3xl p-8 shadow-xl">
                     <h2 className="font-display text-3xl">Where to Stay</h2>
                     <p className="mt-3 text-rose-900/75">
-                        We have secured special rates at our favorite Pearl District hotels. Mention “Alondra Mis XV” when booking to
-                        be added to the welcome list.
+                        Stay right on property to enjoy the ocean breeze and effortless access to every event. Mention “Quinceañera
+                        Alondra” and reservation code 334 to be added to our welcome list and receive the group rate.
                     </p>
                     <div className="mt-6 space-y-6">
                         {HOTELS.map((hotel) => (
@@ -122,7 +169,8 @@ export default function Travel() {
                     <div>
                         <h2 className="font-display text-3xl">Flying In</h2>
                         <p className="mt-3 text-rose-900/75">
-                            Both airports offer nonstop routes and easy transportation options. Rideshare pick-up zones are well marked.
+                            Choose between Aguadilla (BQN) about 40 minutes away or San Juan (SJU) at roughly 2 hours 20 minutes. Both
+                            offer reliable ground transportation to Rincón.
                         </p>
                     </div>
                     <div className="space-y-4">
@@ -136,11 +184,41 @@ export default function Travel() {
                     </div>
                     <div className="rounded-3xl border border-rose-100 bg-white/85 p-5 shadow">
                         <h3 className="text-lg font-semibold text-rose-600">Ground Transportation</h3>
-                        <ul className="mt-3 space-y-2 text-sm text-rose-900/70">
-                            <li><strong>Rideshare:</strong> Use “Pearl Stable” as your drop-off pin.</li>
-                            <li><strong>Shuttle:</strong> Hotel Emma & Canopy shuttles depart at 3:45 PM and 4:00 PM.</li>
-                            <li><strong>Parking:</strong> Validation provided for the Koehler Garage (levels 2–4).</li>
-                        </ul>
+                        <p className="mt-2 text-sm text-rose-900/70">Uber operates throughout Puerto Rico, and the following taxi teams are happy to help:</p>
+                        <div className="mt-4 space-y-4 text-sm text-rose-900/70">
+                            <div>
+                                <p className="font-semibold text-rose-600">From San Juan Airport (SJU)</p>
+                                <ul className="mt-2 space-y-1">
+                                    {TAXI_SERVICES.sju.map((service) => (
+                                        <li key={service.name}>
+                                            {service.name}{' '}
+                                            <a
+                                                href={`tel:${service.phone.replace(/[^0-9]/g, '')}`}
+                                                className="font-semibold text-rose-500 underline-offset-4 hover:underline"
+                                            >
+                                                {service.phone}
+                                            </a>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                            <div>
+                                <p className="font-semibold text-rose-600">From Aguadilla Airport (BQN)</p>
+                                <ul className="mt-2 space-y-1">
+                                    {TAXI_SERVICES.bqn.map((service) => (
+                                        <li key={service.name}>
+                                            {service.name}{' '}
+                                            <a
+                                                href={`tel:${service.phone.replace(/[^0-9]/g, '')}`}
+                                                className="font-semibold text-rose-500 underline-offset-4 hover:underline"
+                                            >
+                                                {service.phone}
+                                            </a>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        </div>
                     </div>
                 </aside>
             </section>
@@ -149,8 +227,8 @@ export default function Travel() {
                 <div className="glass-panel rounded-3xl p-8 shadow-xl">
                     <h2 className="font-display text-3xl">Weekend Highlights</h2>
                     <p className="mt-3 text-rose-900/75">
-                        Make the most of your time in San Antonio. Here are a few of Alondra’s favorite spots within walking distance of
-                        the Pearl.
+                        Make the most of your time in Rincón. These moments capture the relaxed coastal vibe Alondra loves sharing with
+                        family and friends.
                     </p>
                     <ul className="mt-6 space-y-4 text-rose-900/70">
                         {LOCAL_TIPS.map((tip) => (
@@ -163,8 +241,8 @@ export default function Travel() {
                 </div>
                 <div className="glass-panel rounded-3xl p-0 shadow-xl">
                     <iframe
-                        title="The Pearl Stable Directions"
-                        src="https://maps.google.com/maps?q=307%20Pearl%20Pkwy%2C%20San%20Antonio%2C%20TX%2078215&t=&z=15&ie=UTF8&iwloc=&output=embed"
+                        title="Rincón of the Seas Grand Caribbean Hotel &amp; Villa Directions"
+                        src="https://maps.google.com/maps?q=Rinc%C3%B3n%20of%20the%20Seas%20Grand%20Caribbean%20Hotel%20%26%20Villa&t=&z=15&ie=UTF8&iwloc=&output=embed"
                         className="h-full min-h-[360px] w-full rounded-3xl"
                         loading="lazy"
                         referrerPolicy="no-referrer-when-downgrade"

--- a/Alondra_Website/src/Travel.jsx
+++ b/Alondra_Website/src/Travel.jsx
@@ -1,0 +1,177 @@
+import './App.css';
+
+const VENUE_ADDRESS = '307 Pearl Pkwy, San Antonio, TX 78215';
+
+const HOTELS = [
+    {
+        name: 'Hotel Emma',
+        distance: 'On-site at Pearl District',
+        description:
+            'Luxury accommodations with historic charm. Request the “Alondra Mis XV” rate for welcome bag delivery and late checkout.',
+        perks: ['Complimentary welcome paletas', 'Access to rooftop pool', '2-minute walk to The Pearl Stable']
+    },
+    {
+        name: 'Canopy by Hilton San Antonio Riverwalk',
+        distance: '0.6 miles from venue',
+        description:
+            'Trendy riverside stay with easy access to the River Walk. Mention the quinceañera room block for discounted valet parking.',
+        perks: ['Breakfast vouchers included', 'River Walk views', 'Shuttle to the venue at 3:45 PM']
+    }
+];
+
+const AIRPORTS = [
+    {
+        code: 'SAT',
+        name: 'San Antonio International Airport',
+        details: 'Closest airport with nonstop flights nationwide. 15-minute rideshare to the Pearl District.'
+    },
+    {
+        code: 'AUS',
+        name: 'Austin-Bergstrom International Airport',
+        details: 'A scenic 75-minute drive south. Perfect for guests extending their Texas getaway.'
+    }
+];
+
+const LOCAL_TIPS = [
+    {
+        title: 'Parking & Arrival',
+        body: 'Complimentary valet begins at 3:45 PM at The Pearl Stable porte-cochère. Self-parking is available in the Koehler Garage (map pins provided below).'
+    },
+    {
+        title: 'Welcome Gatherings',
+        body: 'Join us Friday evening at Larder inside Hotel Emma for cafecito and conchas from 7:00 – 9:00 PM.'
+    },
+    {
+        title: 'Sunday Brunch',
+        body: 'Meet the family at Bakery Lorraine Pearl for a casual send-off brunch beginning at 10:30 AM.'
+    }
+];
+
+export default function Travel() {
+    return (
+        <main className="mx-auto mt-12 flex w-full max-w-6xl flex-col gap-14">
+            <section className="glass-panel rounded-3xl p-8 shadow-xl">
+                <span className="ribbon-tag">Travel Guide</span>
+                <h1 className="mt-4 font-display text-4xl">Plan Your Stay in San Antonio</h1>
+                <p className="mt-3 max-w-3xl text-rose-900/75">
+                    The celebration takes place at <strong>The Pearl Stable</strong>, located at {VENUE_ADDRESS}. Arrive by 4:00 PM to
+                    enjoy welcome refreshments and snap photos around the iconic Pearl grounds before the mass begins.
+                </p>
+                <div className="mt-8 grid gap-6 md:grid-cols-2">
+                    <div className="rounded-3xl border border-rose-100 bg-white/80 p-6 shadow-md">
+                        <h2 className="text-lg font-semibold text-rose-600">Venue Address</h2>
+                        <p className="mt-2 text-rose-900/75">The Pearl Stable</p>
+                        <p className="text-rose-900/60">{VENUE_ADDRESS}</p>
+                        <p className="mt-4 text-sm text-rose-900/60">
+                            Doors open at 3:45 PM for guest seating. Ceremony begins promptly at 4:30 PM with reception to follow.
+                        </p>
+                    </div>
+                    <div className="rounded-3xl border border-rose-100 bg-white/80 p-6 shadow-md">
+                        <h2 className="text-lg font-semibold text-rose-600">Weekend Snapshot</h2>
+                        <ul className="mt-3 space-y-2 text-sm text-rose-900/70">
+                            <li><strong>Friday:</strong> Welcome cafecito at Larder (7:00 PM)</li>
+                            <li><strong>Saturday:</strong> Ceremony & reception at The Pearl Stable (4:30 PM)</li>
+                            <li><strong>Sunday:</strong> Farewell brunch at Bakery Lorraine (10:30 AM)</li>
+                        </ul>
+                        <p className="mt-4 text-sm text-rose-900/60">
+                            Need assistance during the weekend? Text our hostess team at <a className="font-semibold text-rose-500 underline-offset-4 hover:underline" href="tel:2105550199">(210) 555-0199</a>.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            <section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+                <div className="glass-panel rounded-3xl p-8 shadow-xl">
+                    <h2 className="font-display text-3xl">Where to Stay</h2>
+                    <p className="mt-3 text-rose-900/75">
+                        We have secured special rates at our favorite Pearl District hotels. Mention “Alondra Mis XV” when booking to
+                        be added to the welcome list.
+                    </p>
+                    <div className="mt-6 space-y-6">
+                        {HOTELS.map((hotel) => (
+                            <div key={hotel.name} className="rounded-3xl border border-rose-100 bg-white/85 p-6 shadow-md">
+                                <div className="flex flex-col justify-between gap-3 md:flex-row md:items-center">
+                                    <div>
+                                        <h3 className="text-xl font-semibold text-rose-600">{hotel.name}</h3>
+                                        <p className="text-sm uppercase tracking-[0.3em] text-rose-400">{hotel.distance}</p>
+                                    </div>
+                                    <a
+                                        href="https://www.google.com/travel/hotels"
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="inline-flex items-center justify-center rounded-full border border-rose-300/80 bg-white/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-500 transition hover:border-rose-400 hover:text-rose-600"
+                                    >
+                                        Check Availability
+                                    </a>
+                                </div>
+                                <p className="mt-4 text-rose-900/70">{hotel.description}</p>
+                                <ul className="mt-4 grid gap-2 text-sm text-rose-900/60 sm:grid-cols-2">
+                                    {hotel.perks.map((perk) => (
+                                        <li key={perk} className="flex items-start gap-2">
+                                            <span className="mt-1 inline-flex h-2.5 w-2.5 flex-none rounded-full bg-rose-400"></span>
+                                            <span>{perk}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                <aside className="glass-panel flex flex-col gap-6 rounded-3xl p-8 shadow-xl">
+                    <div>
+                        <h2 className="font-display text-3xl">Flying In</h2>
+                        <p className="mt-3 text-rose-900/75">
+                            Both airports offer nonstop routes and easy transportation options. Rideshare pick-up zones are well marked.
+                        </p>
+                    </div>
+                    <div className="space-y-4">
+                        {AIRPORTS.map((airport) => (
+                            <div key={airport.code} className="rounded-3xl border border-rose-100 bg-white/85 p-5 shadow">
+                                <p className="text-sm uppercase tracking-[0.3em] text-rose-400">{airport.code}</p>
+                                <h3 className="mt-1 text-lg font-semibold text-rose-600">{airport.name}</h3>
+                                <p className="mt-2 text-sm text-rose-900/70">{airport.details}</p>
+                            </div>
+                        ))}
+                    </div>
+                    <div className="rounded-3xl border border-rose-100 bg-white/85 p-5 shadow">
+                        <h3 className="text-lg font-semibold text-rose-600">Ground Transportation</h3>
+                        <ul className="mt-3 space-y-2 text-sm text-rose-900/70">
+                            <li><strong>Rideshare:</strong> Use “Pearl Stable” as your drop-off pin.</li>
+                            <li><strong>Shuttle:</strong> Hotel Emma & Canopy shuttles depart at 3:45 PM and 4:00 PM.</li>
+                            <li><strong>Parking:</strong> Validation provided for the Koehler Garage (levels 2–4).</li>
+                        </ul>
+                    </div>
+                </aside>
+            </section>
+
+            <section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+                <div className="glass-panel rounded-3xl p-8 shadow-xl">
+                    <h2 className="font-display text-3xl">Weekend Highlights</h2>
+                    <p className="mt-3 text-rose-900/75">
+                        Make the most of your time in San Antonio. Here are a few of Alondra’s favorite spots within walking distance of
+                        the Pearl.
+                    </p>
+                    <ul className="mt-6 space-y-4 text-rose-900/70">
+                        {LOCAL_TIPS.map((tip) => (
+                            <li key={tip.title} className="rounded-3xl border border-rose-100 bg-white/85 p-6 shadow">
+                                <h3 className="text-lg font-semibold text-rose-600">{tip.title}</h3>
+                                <p className="mt-2 text-sm">{tip.body}</p>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+                <div className="glass-panel rounded-3xl p-0 shadow-xl">
+                    <iframe
+                        title="The Pearl Stable Directions"
+                        src="https://maps.google.com/maps?q=307%20Pearl%20Pkwy%2C%20San%20Antonio%2C%20TX%2078215&t=&z=15&ie=UTF8&iwloc=&output=embed"
+                        className="h-full min-h-[360px] w-full rounded-3xl"
+                        loading="lazy"
+                        referrerPolicy="no-referrer-when-downgrade"
+                        allowFullScreen
+                    ></iframe>
+                </div>
+            </section>
+        </main>
+    );
+}


### PR DESCRIPTION
## Summary
- add a top navigation bar that lets guests switch between the home view and a new travel guide while updating the venue information to The Pearl Stable
- create a dedicated travel page with hotel, airport, transportation, and weekend highlight details plus an embedded map for the venue

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d21da61e748333b9e5aa7f80e32a88