### PR TITLE
Add stamp-only entry with phone-number gate and guest list

### DIFF
--- a/Alondra_Website/src/App.css
+++ b/Alondra_Website/src/App.css
@@ -17,37 +17,98 @@ body {
   justify-content: center;
   z-index: 50;
   overflow: hidden;
+}
+
+.envelope-stamp-button {
+  border: none;
+  background: transparent;
+  padding: 0;
   cursor: pointer;
-}
-
-.envelope-bottom {
-  width: 80vw;
-  max-width: 420px;
-  filter: drop-shadow(0 25px 45px rgba(82, 191, 232, 0.18));
-}
-
-.envelope-top {
-  position: absolute;
-  width: 80vw;
-  max-width: 420px;
-  top: 50%;
-  transform: translateY(-100%);
-  transform-origin: bottom center;
-  transition: transform 0.7s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .envelope-stamp {
-  position: absolute;
-  width: 110px;
+  width: 130px;
   cursor: pointer;
-  top: 40%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   filter: drop-shadow(0 10px 25px rgba(162, 126, 172, 0.3));
 }
 
-.envelope-overlay.opened .envelope-top {
-  transform: translateY(-100%) rotateX(-180deg);
+.password-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.65);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 60;
+  padding: 1.5rem;
+}
+
+.password-card {
+  width: min(420px, 100%);
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 30px 60px rgba(82, 191, 232, 0.2);
+  border: 1px solid rgba(211, 214, 247, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: center;
+}
+
+.password-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: rgba(162, 126, 172, 0.95);
+}
+
+.password-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: rgba(82, 191, 232, 0.8);
+}
+
+.password-input {
+  border-radius: 999px;
+  border: 1px solid rgba(211, 214, 247, 0.8);
+  padding: 0.75rem 1rem;
+  text-align: center;
+  font-size: 1rem;
+  outline: none;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.password-input:focus {
+  border-color: rgba(162, 126, 172, 0.7);
+  box-shadow: 0 0 0 3px rgba(185, 245, 255, 0.4);
+}
+
+.password-button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  background: rgba(162, 126, 172, 0.95);
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.password-button:hover {
+  background: rgba(162, 126, 172, 0.85);
+  transform: translateY(-1px);
+}
+
+.password-error {
+  font-size: 0.9rem;
+  color: rgba(201, 73, 73, 0.9);
 }
 
 .font-display {

--- a/Alondra_Website/src/App.jsx
+++ b/Alondra_Website/src/App.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import './App.css';
 import Envelope from './Envelope.jsx';
 import Travel from './Travel.jsx';
+import { guestList } from './data/guestList.js';
 import alondra1 from './alondra_images/alondra1.JPG';
 import alondra2 from './alondra_images/alondra2.JPG';
 import alondra3 from './alondra_images/alondra3.JPG';
@@ -89,9 +90,32 @@ function getTimeRemaining() {
 }
 
 function App() {
-    const [open, setOpen] = useState(false);
+    const [accessStage, setAccessStage] = useState('sealed');
     const [currentPage, setCurrentPage] = useState('home');
     const [timeLeft, setTimeLeft] = useState(() => getTimeRemaining());
+    const [phoneInput, setPhoneInput] = useState('');
+    const [passwordError, setPasswordError] = useState('');
+    const [guestInfo, setGuestInfo] = useState(null);
+
+    const isOpen = accessStage === 'open';
+
+    const normalizePhone = (value) => value.replace(/\D/g, '');
+
+    const handlePasswordSubmit = (event) => {
+        event.preventDefault();
+        const normalized = normalizePhone(phoneInput);
+        const match = guestList.find((entry) => entry.phone === normalized);
+
+        if (match) {
+            setGuestInfo(match);
+            setPasswordError('');
+            setAccessStage('open');
+            setCurrentPage('home');
+            return;
+        }
+
+        setPasswordError('That phone number is not on the guest list. Please try again.');
+    };
 
     useEffect(() => {
         const timer = setInterval(() => {
@@ -115,16 +139,40 @@ function App() {
 
     return (
         <>
-            {!open && (
-                <Envelope
-                    onOpen={() => {
-                        setOpen(true);
-                        setCurrentPage('home');
-                    }}
-                />
+            {accessStage === 'sealed' && (
+                <Envelope onStampClick={() => setAccessStage('password')} />
+            )}
+            {accessStage === 'password' && (
+                <div className="password-overlay">
+                    <form className="password-card" onSubmit={handlePasswordSubmit}>
+                        <p className="password-title">Enter your phone number to continue</p>
+                        <label className="password-label" htmlFor="phone-number">
+                            Phone number
+                        </label>
+                        <input
+                            id="phone-number"
+                            name="phone-number"
+                            type="tel"
+                            autoComplete="tel"
+                            placeholder="(555) 123-4567"
+                            value={phoneInput}
+                            onChange={(event) => {
+                                setPhoneInput(event.target.value);
+                                if (passwordError) {
+                                    setPasswordError('');
+                                }
+                            }}
+                            className="password-input"
+                        />
+                        {passwordError && <p className="password-error">{passwordError}</p>}
+                        <button type="submit" className="password-button">
+                            Unlock Invitation
+                        </button>
+                    </form>
+                </div>
             )}
             <div
-                className={`min-h-screen w-full bg-gradient-to-br from-[rgba(185,245,255,0.85)] via-[rgba(251,208,235,0.85)] to-[rgba(211,214,247,0.9)] px-6 py-12 text-[rgba(162,126,172,0.95)] transition-opacity duration-500 ease-out md:px-10 ${open ? 'opacity-100' : 'opacity-0'}`}
+                className={`min-h-screen w-full bg-gradient-to-br from-[rgba(185,245,255,0.85)] via-[rgba(251,208,235,0.85)] to-[rgba(211,214,247,0.9)] px-6 py-12 text-[rgba(162,126,172,0.95)] transition-opacity duration-500 ease-out md:px-10 ${isOpen ? 'opacity-100' : 'opacity-0'}`}
             >
                 <header className="mx-auto flex w-full max-w-6xl flex-col gap-6 text-center sm:flex-row sm:items-center sm:justify-between">
                     <div className="space-y-1">
@@ -154,6 +202,19 @@ function App() {
                 </header>
                 {currentPage === 'home' ? (
                     <main className="mx-auto mt-12 flex w-full max-w-6xl flex-col gap-20">
+                        {guestInfo && (
+                            <section className="glass-panel rounded-3xl p-6 text-center shadow-lg">
+                                <p className="text-sm uppercase tracking-[0.3em] text-[rgba(82,191,232,0.75)]">
+                                    Invitation Access Confirmed
+                                </p>
+                                <p className="mt-2 text-xl font-semibold">
+                                    Phone: {guestInfo.phone}
+                                </p>
+                                <p className="text-[rgba(162,126,172,0.75)]">
+                                    Tickets reserved: {guestInfo.tickets}
+                                </p>
+                            </section>
+                        )}
                         <section className="text-center" id="home">
                             <div className="flex justify-center">
                                 <span className="ribbon-tag">Mis XV • July 28, 2026</span>

--- a/Alondra_Website/src/Envelope.jsx
+++ b/Alondra_Website/src/Envelope.jsx
@@ -1,25 +1,12 @@
-import { useState } from 'react';
 import stamp from './assets/Alondra_stamp.png';
-import topImg from './assets/alondra_sobre4.png';
-import bottomImg from './assets/alondra_sobre3.png';
 
-export default function Envelope({ onOpen }) {
-  const [opened, setOpened] = useState(false);
-
-  const handleClick = () => {
-    if (!opened) {
-      setOpened(true);
-      setTimeout(() => {
-        onOpen?.();
-      }, 700); // match CSS animation duration
-    }
-  };
-
+export default function Envelope({ onStampClick }) {
   return (
-    <div className={`envelope-overlay ${opened ? 'opened' : ''}`} onClick={handleClick}>
-      <img src={bottomImg} className="envelope-bottom" alt="envelope bottom" />
-      <img src={topImg} className="envelope-top" alt="envelope top" />
-      <img src={stamp} className="envelope-stamp" alt="stamp" />
+    <div className="envelope-overlay">
+      <button type="button" className="envelope-stamp-button" onClick={onStampClick}>
+        <img src={stamp} className="envelope-stamp" alt="stamp" />
+        <span className="sr-only">Open invitation</span>
+      </button>
     </div>
   );
 }

--- a/Alondra_Website/src/data/guestList.js
+++ b/Alondra_Website/src/data/guestList.js
@@ -1,0 +1,5 @@
+export const guestList = [
+  { phone: '5551234567', tickets: 3 },
+  { phone: '5559876543', tickets: 2 },
+  { phone: '5555551212', tickets: 4 }
+];


### PR DESCRIPTION
### Motivation
- Replace the full envelope open animation with a single stamp entry point so visitors must click the stamp to proceed.  
- Add a simple phone-number password gate backed by a local guest list so invited guests can unlock the site and see per-guest ticket counts.  

### Description
- Replace `Envelope.jsx` to render only a stamp button and expose an `onStampClick` callback instead of opening envelope images.  
- Add `src/data/guestList.js` that stores guest phone numbers and ticket counts as one entry per row (example entries provided).  
- Update `App.jsx` to implement an `accessStage` flow (`sealed` → `password` → `open`), a phone input form, phone normalization (`normalizePhone`), guest lookup against `guestList`, and a small guest-info panel that displays the matched phone and `tickets`.  
- Add styles in `App.css` for the stamp button and the password overlay form, and remove the old envelope-top/bottom styles.  

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` after resolving a PostCSS syntax error, and the server reported ready.  
- Ran an automated Playwright script that opened `http://127.0.0.1:4173/`, clicked the stamp button, and captured a screenshot to `artifacts/password-gate.png`, which completed successfully.  
- The CSS syntax error encountered during the first run was fixed and the subsequent dev run and Playwright interaction succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968234dc8b4833395f2484db23799aa)