### PR TITLE
Update RSVP deadline to May 14 (EN/ES)

### DIFF
--- a/Alondra_Website/src/App.jsx
+++ b/Alondra_Website/src/App.jsx
@@ -28,8 +28,8 @@ import usaaZelleQr from './alondra_images/USAA.png';
 const EVENT_DATE = new Date('2026-07-18T18:00:00-04:00');
 const RSVP_DEADLINES = {
     default: {
-        en: 'May 10, 2026',
-        es: '10 de mayo de 2026'
+        en: 'May 14, 2026',
+        es: '14 de mayo de 2026'
     },
     dateChanged: {
         en: 'May 1, 2026',


### PR DESCRIPTION
### Motivation
- Update the displayed RSVP cutoff date from May 10 to May 14 across both English and Spanish views so the site shows the correct RSVP deadline and the RSVP form header matches it.

### Description
- Change `RSVP_DEADLINES.default.en` to `May 14, 2026` and `RSVP_DEADLINES.default.es` to `14 de mayo de 2026` in `src/App.jsx`, which updates all places that render the RSVP deadline from the shared `rsvpDeadline` values.

### Testing
- Searched for the old and new date strings with `rg` and inspected the modified lines with `nl` to confirm the replacements in `src/App.jsx`, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64c9a7ec483338c52002574fdaeb5)