### PR TITLE
Set RSVP date-change deadline to May 27

### DIFF
--- a/Alondra_Website/src/App.jsx
+++ b/Alondra_Website/src/App.jsx
@@ -32,8 +32,8 @@ const RSVP_DEADLINES = {
         es: '14 de mayo de 2026'
     },
     dateChanged: {
-        en: 'May 1, 2026',
-        es: '1 de mayo de 2026'
+        en: 'May 27, 2026',
+        es: '27 de mayo de 2026'
     }
 };
 


### PR DESCRIPTION
### Motivation
- Guests marked with an `X` in the CSV "Date Change" column should see an alternate RSVP deadline of May 27 instead of the previous alternate date, and this must appear in both English and Spanish site views.

### Description
- Updated the `dateChanged` deadline strings in `Alondra_Website/src/App.jsx` so `en` is `"May 27, 2026"` and `es` is `"27 de mayo de 2026"`.
- No changes were made to the guest lookup logic; the site continues to use `guestInfo?.hasDateChange ? RSVP_DEADLINES.dateChanged : RSVP_DEADLINES.default` to decide which deadline to show.

### Testing
- Ran the linter with `npm -C /workspace/Alondra_Website/Alondra_Website run lint` which completed with no errors and reported 2 non-blocking React hook warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0508c57f7c83338251d86c92fcf293)