### PR TITLE
Handle June 11 RSVP date changes

### DIFF
--- a/Alondra_Website/src/App.jsx
+++ b/Alondra_Website/src/App.jsx
@@ -34,6 +34,10 @@ const RSVP_DEADLINES = {
     dateChanged: {
         en: 'May 27, 2026',
         es: '27 de mayo de 2026'
+    },
+    dateChangedJune11: {
+        en: 'June 11, 2026',
+        es: '11 de junio de 2026'
     }
 };
 
@@ -355,7 +359,7 @@ function App() {
     const canAccessTravelPage = guestInfo?.experience?.pages?.travel ?? true;
     const welcomePrefix = lang === 'es' ? 'Bienvenido' : 'Welcome';
     const welcomeTitle = guestInfo?.title || guestInfo?.phone || '';
-    const rsvpDeadline = guestInfo?.hasDateChange ? RSVP_DEADLINES.dateChanged : RSVP_DEADLINES.default;
+    const rsvpDeadline = RSVP_DEADLINES[guestInfo?.dateChangeDeadlineKey] ?? RSVP_DEADLINES.default;
 
     const playBackgroundTrack = () => {
         if (!isMusicEnabled) {

--- a/Alondra_Website/src/data/guestList.js
+++ b/Alondra_Website/src/data/guestList.js
@@ -61,7 +61,20 @@ const parseInteger = (value) => {
     return Number.isFinite(parsed) ? parsed : 0;
 };
 
-const parseDateChangeFlag = (value = '') => String(value).trim().toUpperCase() === 'X';
+const DATE_CHANGE_DEADLINE_KEYS = {
+    X: 'dateChanged',
+    Y: 'dateChangedJune11'
+};
+
+const parseDateChangeDeadlineKey = (value = '') => DATE_CHANGE_DEADLINE_KEYS[String(value).trim().toUpperCase()] ?? null;
+
+const getPreferredDeadlineKey = (currentKey, nextKey) => {
+    if (nextKey === 'dateChangedJune11' || currentKey === 'dateChangedJune11') {
+        return 'dateChangedJune11';
+    }
+
+    return currentKey ?? nextKey;
+};
 
 const parseCsvRow = (row = '') => {
     const columns = [];
@@ -124,7 +137,7 @@ const parseGuestList = (csvText) => {
         const region = normalizeRegion(columns[regionIndex] ?? '');
         const tickets = parseInteger(columns[ticketsIndex] ?? '');
         const title = String(columns[titleIndex] ?? '').trim();
-        const hasDateChange = dateChangeIndex !== -1 && parseDateChangeFlag(columns[dateChangeIndex] ?? '');
+        const dateChangeDeadlineKey = dateChangeIndex !== -1 ? parseDateChangeDeadlineKey(columns[dateChangeIndex] ?? '') : null;
         const existing = guestsByPhone.get(phone);
 
         if (!existing) {
@@ -133,7 +146,8 @@ const parseGuestList = (csvText) => {
                 region,
                 tickets,
                 title,
-                hasDateChange
+                hasDateChange: Boolean(dateChangeDeadlineKey),
+                dateChangeDeadlineKey
             });
             continue;
         }
@@ -143,7 +157,8 @@ const parseGuestList = (csvText) => {
             region: existing.region || region,
             tickets: Math.max(existing.tickets, tickets),
             title: existing.title || title,
-            hasDateChange: existing.hasDateChange || hasDateChange
+            dateChangeDeadlineKey: getPreferredDeadlineKey(existing.dateChangeDeadlineKey, dateChangeDeadlineKey),
+            hasDateChange: existing.hasDateChange || Boolean(dateChangeDeadlineKey)
         });
     }
 


### PR DESCRIPTION
### Motivation
- The guest CSV includes a new `Y` value in the `Date change` column that should map some guests to a June 11 RSVP deadline instead of the existing May 27 or default May 14 dates. 
- RSVP messaging must display the correct deadline in both English and Spanish everywhere it appears. 
- When multiple rows exist for the same phone, the parsing/merge logic must prefer the June 11 deadline if any row indicates it.

### Description
- Add `DATE_CHANGE_DEADLINE_KEYS` mapping and `parseDateChangeDeadlineKey` helper to interpret `X` and `Y` CSV values and produce a deadline key. 
- Add `getPreferredDeadlineKey` and store `dateChangeDeadlineKey` on parsed guest entries while preserving `hasDateChange` for compatibility. 
- Update `parseGuestList` merge logic to prefer the `dateChangedJune11` key when deduping entries. 
- Add a `dateChangedJune11` entry to `RSVP_DEADLINES` and change RSVP lookup in `src/App.jsx` to use `RSVP_DEADLINES[guestInfo?.dateChangeDeadlineKey] ?? RSVP_DEADLINES.default` so English and Spanish copy both show the selected date.

### Testing
- Verified parsing with a scripted runtime check using `node --input-type=module` that the two current `Y` guests in `src/data/GuestList.csv` produce `dateChangeDeadlineKey === 'dateChangedJune11'` and retain `hasDateChange=true`. 
- Ran `npm run lint && npm run build` which completed successfully; lint still reports the pre-existing React hook dependency warnings in `src/App.jsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19b89acf508333821c2883a784e1f5)