### PR TITLE
Handle Z RSVP date changes

### DIFF
--- a/Alondra_Website/src/App.jsx
+++ b/Alondra_Website/src/App.jsx
@@ -38,6 +38,10 @@ const RSVP_DEADLINES = {
     dateChangedJune11: {
         en: 'June 11, 2026',
         es: '11 de junio de 2026'
+    },
+    dateChangedJune25: {
+        en: 'June 25, 2026',
+        es: '25 de junio de 2026'
     }
 };
 

--- a/Alondra_Website/src/data/guestList.js
+++ b/Alondra_Website/src/data/guestList.js
@@ -63,17 +63,31 @@ const parseInteger = (value) => {
 
 const DATE_CHANGE_DEADLINE_KEYS = {
     X: 'dateChanged',
-    Y: 'dateChangedJune11'
+    Y: 'dateChangedJune11',
+    Z: 'dateChangedJune25'
 };
 
 const parseDateChangeDeadlineKey = (value = '') => DATE_CHANGE_DEADLINE_KEYS[String(value).trim().toUpperCase()] ?? null;
 
+const DATE_CHANGE_DEADLINE_PRIORITY = [
+    'dateChanged',
+    'dateChangedJune11',
+    'dateChangedJune25'
+];
+
 const getPreferredDeadlineKey = (currentKey, nextKey) => {
-    if (nextKey === 'dateChangedJune11' || currentKey === 'dateChangedJune11') {
-        return 'dateChangedJune11';
+    if (!currentKey) {
+        return nextKey;
     }
 
-    return currentKey ?? nextKey;
+    if (!nextKey) {
+        return currentKey;
+    }
+
+    const currentPriority = DATE_CHANGE_DEADLINE_PRIORITY.indexOf(currentKey);
+    const nextPriority = DATE_CHANGE_DEADLINE_PRIORITY.indexOf(nextKey);
+
+    return nextPriority > currentPriority ? nextKey : currentKey;
 };
 
 const parseCsvRow = (row = '') => {


### PR DESCRIPTION
### Motivation
- Guest CSV contains a new `Z` value in the `Date change` column which should map to a new June 25 RSVP deadline and be honored for both English and Spanish displays. 
- When multiple rows share the same phone number, the code should pick the latest applicable date-change deadline so guests see the correct deadline. 

### Description
- Added mapping for `Z` to a new `dateChangedJune25` key in `Alondra_Website/src/data/guestList.js` and added the corresponding `dateChangedJune25` entry to `RSVP_DEADLINES` in `Alondra_Website/src/App.jsx`. 
- Replaced the previous ad-hoc merging behavior with a `DATE_CHANGE_DEADLINE_PRIORITY` list and updated `getPreferredDeadlineKey` to choose the later priority when merging duplicate phone rows so the most recent date-change wins. 
- Continued using `parseDateChangeDeadlineKey` in CSV parsing so `Z` values are parsed into the new deadline key and the UI automatically displays the localized deadline via the existing `rsvpDeadline` lookup. 

### Testing
- Ran `npm run build` which completed successfully and produced the production bundle. 
- Ran `npm run lint` which completed with no errors but reported two existing React hook dependency warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a297fa7a4b88333848e5442b714f865)